### PR TITLE
Fix a bug, that caused unexpected behaivor

### DIFF
--- a/effects/src/main/java/sunsetsatellite/catalyst/effects/api/effect/EffectContainer.java
+++ b/effects/src/main/java/sunsetsatellite/catalyst/effects/api/effect/EffectContainer.java
@@ -30,12 +30,14 @@ public class EffectContainer<T> {
 	public void add(EffectStack effectStack){
 		for (EffectStack effect : effects) {
 			if(effect.getEffect() == effectStack.getEffect()){
-				if(effect.getAmount()+ effectStack.getAmount() <= effect.getEffect().getMaxStack()){
-					effect.add(effectStack.getAmount(),this);
-					return;
-				} else {
-					return;
+				int amount;
+				if(effect.getAmount() + effectStack.getAmount() >= effect.getEffect().getMaxStack()){
+					amount = effect.getEffect().getMaxStack() - effect.getAmount();
+				}else{
+					amount = effectStack.getAmount();
 				}
+				effect.add(amount,this);
+				return;
 			}
 		}
 		effects.add(effectStack);


### PR DESCRIPTION
Fixed a bug where, if the current effect stack size was below the maximum, but adding the new amount would exceed the maximum, nothing would happen.

Example:
- max = 10, current = 7
- add 5 stacks
- current remains 7

post-fix it becomes 10

