### PR TITLE
Fixed extraHearts and improved Effects state handeling

### DIFF
--- a/effects/src/main/java/sunsetsatellite/catalyst/effects/api/attribute/type/IntAttribute.java
+++ b/effects/src/main/java/sunsetsatellite/catalyst/effects/api/attribute/type/IntAttribute.java
@@ -7,7 +7,6 @@ import sunsetsatellite.catalyst.effects.api.modifier.type.NumberModifier;
 
 import java.util.Comparator;
 import java.util.List;
-import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 

--- a/effects/src/main/java/sunsetsatellite/catalyst/effects/api/effect/EffectContainer.java
+++ b/effects/src/main/java/sunsetsatellite/catalyst/effects/api/effect/EffectContainer.java
@@ -38,20 +38,15 @@ public class EffectContainer<T> {
 
 		for (EffectStack effect : effects) {
 			if(effect.getEffect() == effectStack.getEffect()){
-				int amount;
-				if(effect.getAmount() + effectStack.getAmount() >= effect.getEffect().getMaxStack()){
-					amount = effect.getEffect().getMaxStack() - effect.getAmount();
-				}else{
-					amount = effectStack.getAmount();
-				}
+				int amount = Math.min(effectStack.getAmount(), effect.getEffect().getMaxStack() - effect.getAmount());
 				effect.add(amount,this);
-				if (EnvironmentHelper.isServerEnvironment()) NetworkHandler.sendToAllPlayers(new SyncEffectContainerForEntityNetworkMessage((Entity) this.getParent()));
+				syncEffectContainer();
 				return;
 			}
 		}
 
 		effects.add(effectStack);
-		if (EnvironmentHelper.isServerEnvironment()) NetworkHandler.sendToAllPlayers(new SyncEffectContainerForEntityNetworkMessage((Entity) this.getParent()));
+		syncEffectContainer();
 	}
 
 	public void subtract(EffectStack effectStack){
@@ -59,7 +54,7 @@ public class EffectContainer<T> {
 			if(effect.getEffect() == effectStack.getEffect()){
 				effect.subtract(effectStack.getAmount(),this);
 
-				if (EnvironmentHelper.isServerEnvironment()) NetworkHandler.sendToAllPlayers(new SyncEffectContainerForEntityNetworkMessage((Entity) this.getParent()));
+				syncEffectContainer();
 				return;
 			}
 		}
@@ -75,7 +70,7 @@ public class EffectContainer<T> {
 			}
 		}
 
-		if (EnvironmentHelper.isServerEnvironment()) NetworkHandler.sendToAllPlayers(new SyncEffectContainerForEntityNetworkMessage((Entity) this.getParent()));
+		syncEffectContainer();
 	}
 	public void removeAll() {
 		List<EffectStack> copy = new ArrayList<>(effects);
@@ -127,6 +122,12 @@ public class EffectContainer<T> {
 			if(value instanceof CompoundTag){
 				effects.add(new EffectStack((CompoundTag) value));
 			}
+		}
+	}
+
+	private void syncEffectContainer() {
+		if (EnvironmentHelper.isServerEnvironment()) {
+			NetworkHandler.sendToAllPlayers(new SyncEffectContainerForEntityNetworkMessage((Entity) this.getParent()));
 		}
 	}
 }

--- a/effects/src/main/java/sunsetsatellite/catalyst/effects/api/effect/EffectStack.java
+++ b/effects/src/main/java/sunsetsatellite/catalyst/effects/api/effect/EffectStack.java
@@ -82,8 +82,12 @@ public class EffectStack {
 
 	public <T> void tick(EffectContainer<T> effectContainer) {
 		if(state == State.ACTIVE){
+			if(effect.getTimeType() == EffectTimeType.PERMANENT){
+				effect.tick(this,effectContainer);
+				return;
+			}
 			if(timeLeft > 0){
-				if(effect.getTimeType() != EffectTimeType.PERMANENT) timeLeft--;
+				timeLeft--;
 				effect.tick(this,effectContainer);
 			} else {
 				state = State.FINISHED;

--- a/effects/src/main/java/sunsetsatellite/catalyst/effects/api/effect/EffectStack.java
+++ b/effects/src/main/java/sunsetsatellite/catalyst/effects/api/effect/EffectStack.java
@@ -80,6 +80,14 @@ public class EffectStack {
 		}
 	}
 
+	public <T> void finish(EffectContainer<T> effectContainer){
+		if(state == State.ACTIVE){
+			timeLeft = 0;
+			state = State.FINISHED;
+			effect.expired(this,effectContainer);
+		}
+	}
+
 	public <T> void tick(EffectContainer<T> effectContainer) {
 		if(state == State.ACTIVE){
 			if(effect.getTimeType() == EffectTimeType.PERMANENT){
@@ -90,8 +98,7 @@ public class EffectStack {
 				timeLeft--;
 				effect.tick(this,effectContainer);
 			} else {
-				state = State.FINISHED;
-				effect.expired(this,effectContainer);
+				this.finish(effectContainer);
 			}
 		}
 	}

--- a/effects/src/main/java/sunsetsatellite/catalyst/effects/helper/HealthHelper.java
+++ b/effects/src/main/java/sunsetsatellite/catalyst/effects/helper/HealthHelper.java
@@ -26,11 +26,11 @@ public class HealthHelper {
      * @param amount the amount of extra health they should have
      */
     public static void setExtraHealth(Player player, int amount) {
-
         EffectContainer<?> container = ((IHasEffects<?>) player).getContainer();
-
         container.remove(Effects.EXTRA_HEALTH);
-        container.add(new EffectStack((IHasEffects<?>) player, Effects.EXTRA_HEALTH, amount));
+		EffectStack stack = new EffectStack((IHasEffects<?>) player, Effects.EXTRA_HEALTH, amount);
+		container.add(stack);
+		stack.start(container);
     }
 
     /**
@@ -40,8 +40,12 @@ public class HealthHelper {
      * @param amount the amount of extra health to add, on top of the amount they already have
      */
     public static void addExtraHealth(Player player, int amount) {
-        ((IHasEffects<?>) player).getContainer().add(new EffectStack((IHasEffects<?>) player, Effects.EXTRA_HEALTH, amount));
+		EffectStack stack = new EffectStack((IHasEffects<?>) player, Effects.EXTRA_HEALTH, amount);
+		EffectContainer<?> container = ((IHasEffects<?>) player).getContainer();
+		container.add(stack);
+		stack.start(container);
     }
+
 
     /**
      * Get the total/max health of a player (20 + extra health)


### PR DESCRIPTION
Hi Martin,
this is a fix to the extraHearts. I changed Helper to activate the effects and made it so permanent effects do not decay regardless of set duration. 

Here is a list of all changes:
- Permanent Effects dont decay once active
- active Effects can be forced to finish
- simplifies the logic for EffectsStack add
- HealthHelper now activates the effect as well